### PR TITLE
Set new 7 days default for the authorization expiration time.

### DIFF
--- a/Model/Api/PayloadBuilder.php
+++ b/Model/Api/PayloadBuilder.php
@@ -131,7 +131,7 @@ class PayloadBuilder
         $billingAddress = $quote->getBillingAddress();
         $tokenize = $this->sezzleConfig->isInContextCheckout()
             ? false
-            : $this->sezzleConfig->isTokenizationAllowed();
+            : $this->sezzleConfig->isTokenizationAllowed() && !$quote->getCustomerIsGuest();
         return [
             "tokenize" => $tokenize,
             "email" => $quote->getCustomerEmail(),

--- a/Model/System/Config/Container/SezzleConfigInterface.php
+++ b/Model/System/Config/Container/SezzleConfigInterface.php
@@ -38,6 +38,13 @@ interface SezzleConfigInterface extends IdentityInterface
     public function getPaymentMode();
 
     /**
+     * Get authorization duration in days.
+     * @return string|null
+     * @throws NoSuchEntityException
+     */
+    public function getAuthorizationDuration();
+
+    /**
      * Get Merchant UUID
      * @return string|null
      * @throws NoSuchEntityException

--- a/Model/System/Config/Container/SezzleIdentity.php
+++ b/Model/System/Config/Container/SezzleIdentity.php
@@ -25,6 +25,7 @@ class SezzleIdentity extends Container implements SezzleConfigInterface
     const XML_PATH_PRIVATE_KEY = 'payment/sezzlepay/private_key';
     const XML_PATH_MERCHANT_ID = 'payment/sezzlepay/merchant_id';
     const XML_PATH_PAYMENT_ACTION = 'payment/sezzlepay/payment_action';
+    const XML_PATH_AUTHORIZATION_DURATION = 'payment/sezzlepay/authorization_duration';
     const XML_PATH_MIN_CHECKOUT_AMOUNT = 'payment/sezzlepay/min_checkout_amount';
     const XML_PATH_STATIC_WIDGET = 'payment/sezzlepay/static_widget';
     const XML_PATH_WIDGET_PDP = 'payment/sezzlepay/widget_pdp';
@@ -84,6 +85,17 @@ class SezzleIdentity extends Container implements SezzleConfigInterface
     {
         return $this->getConfigValue(
             self::XML_PATH_PAYMENT_MODE,
+            $this->getStore()->getStoreId()
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAuthorizationDuration()
+    {
+        return $this->getConfigValue(
+            self::XML_PATH_AUTHORIZATION_DURATION,
             $this->getStore()->getStoreId()
         );
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -74,6 +74,14 @@
                         <source_model>Sezzle\Sezzlepay\Model\System\Config\Source\Payment\PaymentAction</source_model>
                         <config_path>payment/sezzlepay/payment_action</config_path>
                     </field>
+                    <field id="authorization_duration" translate="label comment" type="text" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Authorization duration</label>
+                        <comment>Authorization duration in days (default is 7 days)</comment>
+                        <config_path>payment/sezzlepay/authorization_duration</config_path>
+                        <depends>
+                            <field id="payment_action">authorize</field>
+                        </depends>
+                    </field>
                     <!-- tokenize -->
                     <field id="tokenize" translate="label" type="select" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Enable Customer Tokenization?</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -17,6 +17,7 @@
                 <payment_mode>sandbox</payment_mode>
                 <log_tracker>1</log_tracker>
                 <payment_action>authorize_capture</payment_action>
+                <authorization_duration>7</authorization_duration>
                 <active_in_context>0</active_in_context>
                 <tokenize>1</tokenize>
                 <sort_order>0</sort_order>


### PR DESCRIPTION
This adds an admin config so that the store can set the duration for the authorization request with a default of 7 days.
This fixes issue https://github.com/sezzle/sezzle-magento2/issues/9